### PR TITLE
矢印キーでコマンド履歴を遡っている時に、前のコマンドが消えず残っている場合があるバグを修正

### DIFF
--- a/com.ps1
+++ b/com.ps1
@@ -21,7 +21,7 @@ $params = @{
     }
 }
 
-[double] $version = 1.5
+[double] $version = 1.6
 [string] $copyright = "(c) 2019, Hayato Doi."
 function sirialStart() {
 

--- a/com.ps1
+++ b/com.ps1
@@ -81,7 +81,7 @@ function sirialStart() {
                     # $dORj -eq "J"
                     else {
                         if ($num -eq 0) {
-                            Write-Host -NoNewline (" " * ([System.Console]::WindowHeight - $cursorLeft) )
+                            Write-Host -NoNewline (" " * ($Host.UI.RawUI.BufferSize.Width - $cursorLeft))
                             [System.Console]::SetCursorPosition($cursorLeft, $cursorTop)
                         }
                     }


### PR DESCRIPTION
close #9 